### PR TITLE
Fix payment popup not showing up

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,7 @@
                     </div>
 
                     <h3 id="total-price">Total price:</h3>
-                    <button class="purchase-button" id="purchase-btn">
-                       <strong>Complete order</strong>
-                    </button>
+                    <button class="purchase-button" id="purchase-btn">Complete order</button>
                 </div>
             </section>
 


### PR DESCRIPTION
It turns out that if you clicked precisely on the "Complete order" text on the button, the event listener registered on `document` would get invoked with `e.target` being `<strong>Complete order</strong>`, and not the button itself:
<img width="1121" alt="Screenshot 2024-02-19 at 08 09 07" src="https://github.com/OlenaG8/japanese-restaurant-ordering-app/assets/3056812/2ede9245-c680-4700-900b-3c722cae0fbf">

The issue didn't have anything to do with the number of items in the cart. The simple fix is to remove `<strong>`, as it doesn't seem to affect the styling. That way you'll always end up with an event for the button and not its child element.

I think a better approach could be to register separate event handlers on the individual buttons/other elements instead of a global one, which tries to determine what happened based on the `target.id` or `target.dataset`. (Actually there are two global handlers, since there's another one on `window`.) But this works, too. 😉 